### PR TITLE
fix insufficient typing of event listeners

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1295,7 +1295,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
             for block in self.blocks.values()
         )
 
-    def unload(self, fn: Callable):
+    def unload(self, fn: Callable[..., Any]) -> None:
         """This listener is triggered when the user closes or refreshes the tab, ending the user session.
         It is useful for cleaning up resources when the app is closed.
         Parameters:

--- a/gradio/component_meta.py
+++ b/gradio/component_meta.py
@@ -14,10 +14,12 @@ from gradio.utils import no_raise_exception
 
 INTERFACE_TEMPLATE = '''
 {{ contents }}
+    from typing import Callable, Literal
+    from gradio.blocks import Block
 
     {% for event in events %}
     def {{ event }}(self,
-        fn: Callable | None = None,
+        fn: Callable[..., Any] | None = None,
         inputs: Block | Sequence[Block] | set[Block] | None = None,
         outputs: Block | Sequence[Block] | None = None,
         api_name: str | None | Literal[False] = None,

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -986,8 +986,8 @@ def update(
     elem_id: str | None = None,
     elem_classes: list[str] | str | None = None,
     visible: bool | None = None,
-    **kwargs,
-) -> dict:
+    **kwargs: Any,
+) -> dict[str, Any]:
     """
     Updates a component's properties. When a function passed into a Gradio Interface or a Blocks events returns a value, it typically updates the value of the output component. But it is also possible to update the *properties* of an output component (such as the number of lines of a `Textbox` or the visibility of an `Row`) by returning a component and passing in the parameters to update in the constructor of the component. Alternatively, you can return `gr.update(...)` with any arbitrary parameters to update. (This is useful as a shorthand or if the same function can be called with different components to update.)
 


### PR DESCRIPTION
## Description

Adds missing typing to some exported definitions from `gradio/helpers.py`, `gradio/blocks.py` as well as stub files generated by `INTERFACE_TEMPLATE` from `gradio/component_meta.py`

Closes: #8928
